### PR TITLE
Found some bug overwritting results of parallel construct in parallelFor

### DIFF
--- a/src/main/java/at/enactmentengine/serverless/nodes/ParallelEndNode.java
+++ b/src/main/java/at/enactmentengine/serverless/nodes/ParallelEndNode.java
@@ -200,8 +200,10 @@ public class ParallelEndNode extends Node {
         }
 
         /* Clone the node */
-        Node node = (Node) super.clone();
+        ParallelEndNode node = (ParallelEndNode) super.clone();
         node.children = new ArrayList<>();
+        node.parallelResult = new HashMap<>();
+
         for (Node childrenNode : children) {
             node.children.add(childrenNode.clone(endNode));
         }


### PR DESCRIPTION
When a parallelFor is executed all contained nodes are cloned according to the counter. When one of the nodes inside parallelFor is a parallel construct the parallel is correctly cloned. The issue is that only the object is cloned and therefore the attributes are the same. The bug is that all cloned ParallelEndNodes use the same instance of a HashMap to store their result despite them being different nodes. The result is that the different parallel clones overwrite the output data of the other clones and in the end all following nodes get the same input data.