### PR TITLE
Feature/web service workflows

### DIFF
--- a/src/main/java/at/enactmentengine/serverless/nodes/FunctionNode.java
+++ b/src/main/java/at/enactmentengine/serverless/nodes/FunctionNode.java
@@ -155,8 +155,13 @@ public class FunctionNode extends Node {
                             actualFunctionInputs.put(data.getName(), dataValues.get(data.getSource()));
                         }
                     } else {
-                        throw new MissingInputDataException(FunctionNode.class.getCanonicalName() + ": " + name
-                                + " needs " + data.getSource() + " !");
+                        // constant value in the workflow
+                        if(data.getSource() == null && data.getValue() != null) {
+                            actualFunctionInputs.put(data.getName(), data.getValue());
+                        } else {
+                            throw new MissingInputDataException(FunctionNode.class.getCanonicalName() + ": " + name
+                                    + " needs " + data.getSource() + " !");
+                        }
                     }
                 }
             }

--- a/src/main/java/at/enactmentengine/serverless/nodes/FunctionNode.java
+++ b/src/main/java/at/enactmentengine/serverless/nodes/FunctionNode.java
@@ -396,7 +396,7 @@ public class FunctionNode extends Node {
                         functionOutputs.put(name + "/" + data.getName(), jsonResult.get(data.getName()).getAsJsonArray());
                         break;
                     case "object":
-                        functionOutputs.put(name + "/" + data.getName(), jsonResult);
+                        functionOutputs.put(name + "/" + data.getName(), jsonResult.get(data.getName()));
                         break;
                     case "bool":
                         functionOutputs.put(name + "/" + data.getName(), jsonResult.get(data.getName()).getAsBoolean());

--- a/src/main/java/at/enactmentengine/serverless/nodes/FunctionNode.java
+++ b/src/main/java/at/enactmentengine/serverless/nodes/FunctionNode.java
@@ -148,10 +148,22 @@ public class FunctionNode extends Node {
                     /* Check if actual data contains the specified source */
                     if (dataValues.containsKey(data.getSource())) {
 
+
+                        boolean replicate = false;
+                        if(data.getProperties() != null) {
+                            PropertyConstraint replicateConstraint = Utils.getPropertyConstraintByName(data.getProperties(), "replicate");
+                            if (replicateConstraint != null) {
+                                replicate = Boolean.parseBoolean(replicateConstraint.getValue());
+                            }
+                        }
+
+                        boolean passing = data.getPassing() != null && data.getPassing();
+
                         /* Check if the element should be passed to the output */
-                        if (data.getPassing() != null && data.getPassing()) {
+                        if (passing || replicate) {
                             functionOutputs.put(name + "/" + data.getName(), dataValues.get(data.getSource()));
-                        } else {
+                        }
+                        if (!passing) {
                             actualFunctionInputs.put(data.getName(), dataValues.get(data.getSource()));
                         }
                     } else {

--- a/src/main/java/at/enactmentengine/serverless/nodes/ParallelForStartNode.java
+++ b/src/main/java/at/enactmentengine/serverless/nodes/ParallelForStartNode.java
@@ -5,8 +5,10 @@ import at.enactmentengine.serverless.parser.ElementIndex;
 import at.uibk.dps.afcl.functions.objects.DataIns;
 import at.uibk.dps.afcl.functions.objects.LoopCounter;
 import at.uibk.dps.afcl.functions.objects.PropertyConstraint;
+import com.github.fge.jsonschema.core.tree.JsonTree;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
+import com.google.gson.internal.LinkedTreeMap;
 import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -383,9 +385,21 @@ public class ParallelForStartNode extends Node {
                             List<JsonArray> distributedElements = distributeElements(dataElements, data.getConstraints(), children);
 
                             checkDistributedElements(distributedElements, data, values);
+                        } else if (dataValues.get(data.getSource()) instanceof Boolean) {
+                            JsonArray dataElements = new JsonArray();
+                            dataElements.add((Boolean) dataValues.get(data.getSource()));
+                            List<JsonArray> distributedElements = distributeElements(dataElements, data.getConstraints(), children);
+
+                            checkDistributedElements(distributedElements, data, values);
                         } else if (dataValues.get(data.getSource()) instanceof String) {
                             JsonArray dataElements = new JsonArray();
                             dataElements.add((String) dataValues.get(data.getSource()));
+                            List<JsonArray> distributedElements = distributeElements(dataElements, data.getConstraints(), children);
+
+                            checkDistributedElements(distributedElements, data, values);
+                        } else if (dataValues.get(data.getSource()) instanceof LinkedTreeMap) {
+                            JsonArray dataElements = new JsonArray();
+                            dataElements.add(new Gson().toJson(dataValues.get(data.getSource())));
                             List<JsonArray> distributedElements = distributeElements(dataElements, data.getConstraints(), children);
 
                             checkDistributedElements(distributedElements, data, values);
@@ -452,7 +466,13 @@ public class ParallelForStartNode extends Node {
 
                 /* Extract a single value */
                 JsonArray arr = distributedElements.get(i);
-                block = "number".equals(data.getType()) ? arr.get(0).getAsInt() : arr.get(0).getAsString();
+                if("number".equals(data.getType())){
+                    block = arr.get(0).getAsInt();
+                } else if("bool".equals(data.getType())){
+                    block = arr.get(0).getAsBoolean();
+                } else {
+                    block = arr.get(0).getAsString();
+                }
             }
 
             // TODO check if this should be dynamic

--- a/src/main/java/at/enactmentengine/serverless/object/Utils.java
+++ b/src/main/java/at/enactmentengine/serverless/object/Utils.java
@@ -134,7 +134,7 @@ public class Utils {
             throw new MissingResourceLinkException("No resource link on function node " + node.toString());
         }
 
-        if (!resourceLink.startsWith("http") && !resourceLink.startsWith("arn")) {
+        if (!resourceLink.toLowerCase().startsWith("http") && !resourceLink.startsWith("arn")) {
 
             /* Remove the programming language of the resource link */
             resourceLink = resourceLink.substring(resourceLink.indexOf(":") + 1);


### PR DESCRIPTION
### Web Service Workflows

This PR adds some convenience features for working with web services in AFCL. 

#### Constant data-ins for function nodes

This allows to specify hardcoded values for certain
function datains without specifying them in the input json
for the whole workflow and carrying them through every node.

For example:
```yaml
    - function:
        name: "example"
        type: "Collection"
        dataIns:
          - name: someFlag
            type: bool
            value: true
```
#### Replicate property for datains

This allows to pass an input value both
to the output of function and to the function itself.
This is useful for calling services for which the output can not
be changed, but some input data is needed later on in the workflow.
In contrast to the `passing` option this allows the function also consume the datain. 

example:
```yaml
         - name: "param"
            type: "string"
            source: "prevFunction/param"
            properties:
              - name: "replicate"
                value: "true"
```

#### Fixes

see commit messages 
